### PR TITLE
Добавит конфиг для yaspeller и пример общего словаря

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/htmlacademy/configs.git"
+  },
+  "peerDependencies": {
+    "yaspeller": "7.x"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ npm install git+ssh://git@github.com:htmlacademy/configs.git --save-dev
 
 ## yaspeller
 
-Ищет опечатки в материалах. Для настройки необходимо в репозитории курса указать путь к файлу конфигурации.
+Ищет опечатки в материалах. Для настройки необходимо в своём репозитории указать путь к файлу конфигурации.
 
 ```json
 {
@@ -20,7 +20,7 @@ npm install git+ssh://git@github.com:htmlacademy/configs.git --save-dev
 }
 ```
 
-При необходимости можно завести [словарь](https://github.com/hcodes/yaspeller#--dictionary-file) конкретного курса и расширить общий:
+При необходимости можно расширить базовый [словарь](https://github.com/hcodes/yaspeller#--dictionary-file) в своём репе:
 
 ```json
 {
@@ -30,4 +30,4 @@ npm install git+ssh://git@github.com:htmlacademy/configs.git --save-dev
 }
 ```
 
-_`js-3-dictionary.json` — словарь конкретного курса в той же директории, где и `package.json`._
+_`js-3-dictionary.json` — дополняющий словарь из той же директории, где и `package.json`._

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,27 @@
 ```bash
 npm install git+ssh://git@github.com:htmlacademy/configs.git --save-dev
 ```
+
+## yaspeller
+
+Ищет опечатки в материалах. Для настройки необходимо в репозитории курса указать путь к файлу конфигурации.
+
+```json
+{
+    "scripts": {
+        "spellcheck": "yaspeller --config ./node_modules/configs/yaspeller.json ."
+    }
+}
+```
+
+При необходимости можно завести [словарь](https://github.com/hcodes/yaspeller#--dictionary-file) конкретного курса и расширить общий:
+
+```json
+{
+    "scripts": {
+        "spellcheck": "yaspeller --config ./node_modules/configs/yaspeller.json --dictionary js-3-dictionary.json ."
+    }
+}
+```
+
+_`js-3-dictionary.json` — словарь конкретного курса в той же директории, где и `package.json`._

--- a/yaspeller.json
+++ b/yaspeller.json
@@ -1,0 +1,14 @@
+{
+    "lang": "ru",
+    "fileExtensions": [
+        ".md"
+    ],
+    "checkYo": true,
+    "findRepeatWords": true,
+    "ignoreUrls": true,
+    "dictionary": [
+        "колбэк(а)?",
+        "пулреквест",
+        "форк"
+    ]    
+}


### PR DESCRIPTION
Предложение моё такое, что в этот конфиг попадают общие слова, которые встречаются или могут встретиться на всех курсах (типа "колбэк"), а в локальные словари - слова конкретного курса (например "редьюсер" в курсе по Реакту).

Текущая реализация основную функцию выполняет. Можно установить в проект, подключить и всё будет проверяться. Из критичных проблем: пока не разобрался, как научить спеллер самостоятельно понимать склонения и мн./ед.число, чтобы не писать `колбэк(а)?`.