### PR TITLE
Научит спеллер игнорировать нумерацию критериев

### DIFF
--- a/yaspeller.json
+++ b/yaspeller.json
@@ -6,6 +6,7 @@
     "checkYo": true,
     "findRepeatWords": true,
     "ignoreUrls": true,
+    "ignoreDigits": true,
     "dictionary": [
         "колбэк(а)?",
         "пулреквест",


### PR DESCRIPTION
Возможны сайд эффекты, когда ошибкой не будут слова вроде "avp17h4534", но показалось это лучшим вариантом, чем добавлять в словарь правило "Б(1|2|3|...)"